### PR TITLE
adding support for theme templates to be merged and shown in page attributes

### DIFF
--- a/class-page-template-example.php
+++ b/class-page-template-example.php
@@ -93,6 +93,8 @@ class Page_Template_Plugin {
 			'template-example-two.php' => __( 'Example Page Template II', $this->plugin_slug )
 		);
 
+		$templates = wp_get_theme()->get_page_templates();
+    $templates = array_merge( $templates, $this->templates );
 
 	} // end constructor
 


### PR DESCRIPTION
This should fix the problem when someone is trying to put a template from within a plugin to wp. With this fix the templates from the current theme are added to the array and will also work with the templates that where made in the plugin.
