### PR TITLE
Fix for the issue #12

### DIFF
--- a/class-page-template-example.php
+++ b/class-page-template-example.php
@@ -162,9 +162,9 @@ class Page_Template_Plugin {
 
 		global $post;
 
-        // If no posts found, return to
-        // avoid "Trying to get property of non-object" error
-        if ( !isset( $post ) ) return $template;
+		// If no posts found, return to
+		// avoid "Trying to get property of non-object" error
+		if ( !isset( $post ) ) return $template;
 
 		if ( ! isset( $this->templates[ get_post_meta( $post->ID, '_wp_page_template', true ) ] ) ) {
 			return $template;


### PR DESCRIPTION
When there is no posts found (empty page/archives) an error like this happens:

Notice: Trying to get property of non-object in /Users/wordpress/Applications/MAMP/htdocs/wc.connect.local/stargazer/wp-content/plugins/page-template-example/class-page-template-example.php on line 169

Now the bug is fixed with this pull request :)
